### PR TITLE
Added "Scan at Launch" Preference

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -189,6 +189,13 @@
     //load prefs
     [self.prefsWindowController loadPreferences];
 
+	//check for scan at launch
+	if(YES == [defaults boolForKey:PREF_SCAN_AT_LAUNCH])
+	{
+		//start scanning
+		[self scanButtonHandler:self];
+	}
+	
     return;
 }
 

--- a/Consts.h
+++ b/Consts.h
@@ -49,6 +49,10 @@ static NSString * const SUPPORTED_PLUGINS[] = {@"AuthorizationPlugins", @"Browse
 // ->no updates
 #define PREF_DISABLE_UPDATE_CHECK @"noUpdateCheck"
 
+//prefs
+// ->scan at launch
+#define PREF_SCAN_AT_LAUNCH @"scanAtLaunch"
+
 //disabled state
 #define STATE_DISABLED 0
 

--- a/PrefsWindowController.h
+++ b/PrefsWindowController.h
@@ -36,6 +36,9 @@
 //button for saving output
 @property (weak) IBOutlet NSButton* saveOutputBtn;
 
+//button for scan at launch
+@property (weak) IBOutlet NSButton* scanAtLaunchBtn;
+
 //button for ok/close
 @property (weak) IBOutlet NSButton *okButton;
 
@@ -50,6 +53,9 @@
 
 //save results (at end of scan)
 @property BOOL saveOutput;
+
+//scan at launch
+@property BOOL scanAtLaunch;
 
 //save results now
 @property BOOL shouldSaveNow;

--- a/PrefsWindowController.m
+++ b/PrefsWindowController.m
@@ -69,6 +69,13 @@
         self.disableVTQueriesBtn.state = STATE_ENABLED;
     }
     
+    //check if 'scan at launch' button should be selected
+	if(YES == self.scanAtLaunch)
+    {
+        //set
+		self.scanAtLaunchBtn.state = STATE_ENABLED;
+    }
+    
     //check if 'save output' button should be selected
     if(YES == self.saveOutput)
     {
@@ -133,6 +140,13 @@
             //save
             self.saveOutput = [defaults boolForKey:PREF_SAVE_OUTPUT];
         }
+        
+        //load 'scan at launch'
+		if(nil != [defaults objectForKey:PREF_SCAN_AT_LAUNCH])
+        {
+            //save
+			self.scanAtLaunch = [defaults boolForKey:PREF_SCAN_AT_LAUNCH];
+        }
     }
     
     return;
@@ -152,6 +166,9 @@
     
     //save current state of 'save' button
     self.saveOutput = self.saveOutputBtn.state;
+    
+    //save current state of 'scan at launch' button
+	self.saveOutput = self.scanAtLaunchBtn.state;
     
     return;
 }
@@ -183,6 +200,7 @@
     if( ((self.showTrustedItems != self.showTrustedItemsBtn.state) ||
          (self.disableUpdateCheck != self.disableUpdateCheckBtn.state) ||
          (self.disableVTQueries != self.disableVTQueriesBtn.state) ||
+		 (self.scanAtLaunch != self.scanAtLaunchBtn.state) ||
          (self.saveOutput != self.saveOutputBtn.state) ) &&
          (YES == self.saveOutputBtn.state) )
     {
@@ -205,6 +223,9 @@
     //save disabling VT flag
     self.disableVTQueries = self.disableVTQueriesBtn.state;
     
+    //scan at launch flag
+	self.scanAtLaunch = self.scanAtLaunchBtn.state;
+    
     //save save output flag
     self.saveOutput = self.saveOutputBtn.state;
     
@@ -216,6 +237,9 @@
     
     //save 'disable vt queries'
     [defaults setBool:self.disableVTQueries forKey:PREF_DISABLE_VT_QUERIRES];
+    
+    //save 'scan at launch'
+	[defaults setBool:self.scanAtLaunch forKey:PREF_SCAN_AT_LAUNCH];
     
     //save 'save output'
     [defaults setBool:self.saveOutput forKey:PREF_SAVE_OUTPUT];

--- a/UI/PrefsWindow.xib
+++ b/UI/PrefsWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23090" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23090"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -11,6 +11,7 @@
                 <outlet property="disableUpdateCheckBtn" destination="dJU-Ok-N6U" id="Q9b-gF-V3d"/>
                 <outlet property="disableVTQueriesBtn" destination="d54-mZ-jqy" id="Xx6-E1-yv0"/>
                 <outlet property="okButton" destination="HZZ-Es-mpy" id="GKU-Jc-ENB"/>
+                <outlet property="scanAtLaunchBtn" destination="nSz-8b-bZE" id="PoV-GU-Y5n"/>
                 <outlet property="showTrustedItemsBtn" destination="4xV-kQ-iaT" id="aEg-d4-Orl"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
@@ -19,14 +20,14 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" texturedBackground="YES"/>
-            <rect key="contentRect" x="196" y="240" width="422" height="177"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="contentRect" x="196" y="240" width="422" height="180"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="898"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="422" height="177"/>
+                <rect key="frame" x="0.0" y="0.0" width="422" height="180"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4xV-kQ-iaT">
-                        <rect key="frame" x="101" y="139" width="264" height="18"/>
+                        <rect key="frame" x="101" y="142.5" width="264" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Include macOS/known items." bezelStyle="regularSquare" imagePosition="left" focusRingType="none" inset="2" id="WN8-cQ-8xh">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -34,7 +35,7 @@
                         </buttonCell>
                     </button>
                     <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d54-mZ-jqy">
-                        <rect key="frame" x="101" y="81" width="303" height="19"/>
+                        <rect key="frame" x="101" y="84.5" width="303" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Disable VirusTotal integration." bezelStyle="regularSquare" imagePosition="left" focusRingType="none" inset="2" id="gXW-vY-Aj1">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -42,15 +43,28 @@
                         </buttonCell>
                     </button>
                     <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dJU-Ok-N6U">
-                        <rect key="frame" x="101" y="110" width="303" height="19"/>
+                        <rect key="frame" x="101" y="113.5" width="303" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Disable automatic update check." bezelStyle="regularSquare" imagePosition="left" focusRingType="none" inset="2" id="idJ-pd-k6U">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" size="13" name="Menlo-Regular"/>
                         </buttonCell>
                     </button>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lEv-Wj-6S5">
+                        <rect key="frame" x="20" y="82" width="48" height="48"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="settings" id="xKf-GK-m0k"/>
+                    </imageView>
+                    <button focusRingType="none" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nSz-8b-bZE">
+                        <rect key="frame" x="101" y="58.5" width="303" height="19"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Scan at Launch." bezelStyle="regularSquare" imagePosition="left" focusRingType="none" inset="2" id="a7y-fS-kVf">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" size="13" name="Menlo-Regular"/>
+                        </buttonCell>
+                    </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HZZ-Es-mpy">
-                        <rect key="frame" x="326" y="13" width="82" height="32"/>
+                        <rect key="frame" x="327" y="13" width="82" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="J9x-sM-h9S">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -60,17 +74,12 @@
                             <action selector="closeWindow:" target="-2" id="eFa-k0-zTM"/>
                         </connections>
                     </button>
-                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lEv-Wj-6S5">
-                        <rect key="frame" x="20" y="79" width="48" height="48"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="settings" id="xKf-GK-m0k"/>
-                    </imageView>
                 </subviews>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="318" y="273.5"/>
+            <point key="canvasLocation" x="318" y="275"/>
         </window>
     </objects>
     <resources>


### PR DESCRIPTION
Motivation: I'm managing Macs in my circle of friends. I install KnockKnock on every Mac and add it to the list of Login Items. While it is obvious for power users to click the "Start Scan" button, it isn't for regular users. The "Scan at Launch" pref fixes this problem and makes sure regular users Macs will get scanned at least once on every reboot.