### PR TITLE
fix: add success status marking for help and version flags

### DIFF
--- a/main.m
+++ b/main.m
@@ -23,6 +23,9 @@ int main(int argc, char *argv[])
         {
             //print usage
             usage(NO);
+
+            //mark as success
+            status = 0;
             
             //done
             goto bail;
@@ -33,6 +36,9 @@ int main(int argc, char *argv[])
         {
             //print usage
             version();
+
+            //mark as success
+            status = 0;
             
             //done
             goto bail;


### PR DESCRIPTION
-h, -help and -version should not error out when user got exactly what he asked for. This changes the status code to 0 before returning and exiting.